### PR TITLE
Add Prohibited Address Functionality

### DIFF
--- a/src/core/EntryPoint.sol
+++ b/src/core/EntryPoint.sol
@@ -452,32 +452,29 @@ contract EntryPoint is
     function extractAddressFromIntentData(bytes calldata data) internal pure returns (address) {
         // Implement the logic to extract an address from the data
     }
-    /**
+    
+     /**
      * @dev Checks if any prohibited addresses are included in the UserIntent.
      * @param intent The UserIntent to check.
      * @return True if any prohibited addresses are found, false otherwise.
      */
     function isProhibitedAddressInIntent(UserIntent calldata intent) internal view returns (bool) {
-        // Check sender's address
-        if (isProhibitedAddress[intent.sender]) {
+    // Check sender's address
+    if (isProhibitedAddress[intent.sender]) {
+        return true;
+    }
+
+    // Check addresses within intentData, if applicable
+    for (uint256 i = 0; i < intent.intentData.length; i++) {
+        address extractedAddress = extractAddressFromIntentData(intent.intentData[i]);
+        if (isProhibitedAddress[extractedAddress]) {
             return true;
         }
-
-        // Check addresses within intentData, if applicable
-        for (uint256 i = 0; i < intent.intentData.length; i++) {
-            address extractedAddress = extractAddressFromIntentData(intent.intentData[i]);
-            if (isProhibitedAddress[extractedAddress]) {
-                return true;
-            }
-        }
-
-        // Address is not prohibited
-        return false;
     }
 
+    // Address is not prohibited
+    return false;
 }
-
-    }
 
     /**
      * generates an intent ID for an intent.

--- a/src/core/EntryPoint.sol
+++ b/src/core/EntryPoint.sol
@@ -435,11 +435,12 @@ contract EntryPoint is
     }
     // Access control restriction using the modifier
     function setProhibitedAddresses(address[] calldata addresses, UserIntent calldata intent) external onlyIntentSender(intent) {
-        for (uint256 i = 0; i < addresses.length; i++) {
-            isProhibitedAddress[addresses[i]] = true;
+    for (uint256 i = 0; i < addresses.length; i++) {
+        isProhibitedAddress[addresses[i]] = true;
+        unchecked {
+            i++; // cannot overflow without hitting gas limit
         }
     }
-
     function isProhibitedAddressInIntent(UserIntent calldata intent) internal view returns (bool) {
         // Check sender's address
         if (isProhibitedAddress[intent.sender]) {

--- a/src/core/EntryPoint.sol
+++ b/src/core/EntryPoint.sol
@@ -429,6 +429,46 @@ contract EntryPoint is
         }
     }
 
+    // New function to set prohibited addresses
+    address[] private prohibitedAddresses;
+
+    function setProhibitedAddresses(address[] calldata addresses) external {
+        // Set the list of prohibited addresses
+        prohibitedAddresses = addresses;
+    }
+
+    // New function to check if an address is prohibited
+    function isProhibitedAddress(address addr) internal view returns (bool) {
+        for (uint256 i = 0; i < prohibitedAddresses.length; i++) {
+            if (prohibitedAddresses[i] == addr) {
+                // Address is prohibited
+                return true;
+            }
+        }
+        // Address is not prohibited
+        return false;
+    }
+
+    // New function to check if an address within intentData is prohibited
+    function isProhibitedAddressInIntent(UserIntent calldata intent) internal view returns (bool) {
+        // Check sender's address
+        if (isProhibitedAddress(intent.sender)) {
+            return true;
+        }
+
+        // Check addresses within intentData, if applicable
+        for (uint256 i = 0; i < intent.intentData.length; i++) {
+            address addressInIntent = extractAddressFromIntentData(intent.intentData[i]);
+            if (isProhibitedAddress(addressInIntent)) {
+                return true;
+            }
+        }
+
+        // Address is not prohibited
+        return false;
+    }
+}
+
     /**
      * generates an intent ID for an intent.
      */

--- a/src/core/EntryPoint.sol
+++ b/src/core/EntryPoint.sol
@@ -428,44 +428,37 @@ contract EntryPoint is
             revert FailedIntent(intentIndex, 0, "AA24 signature error (or OOG)");
         }
     }
-
-    // New function to set prohibited addresses
-    address[] private prohibitedAddresses;
-
-    function setProhibitedAddresses(address[] calldata addresses) external {
-        // Set the list of prohibited addresses
-        prohibitedAddresses = addresses;
+    mapping(address => bool) public isProhibitedAddress;
+    modifier onlyIntentSender(UserIntent calldata intent) {
+        require(msg.sender == intent.sender, "Not the intent sender");
+        _;
     }
-
-    // New function to check if an address is prohibited
-    function isProhibitedAddress(address addr) internal view returns (bool) {
-        for (uint256 i = 0; i < prohibitedAddresses.length; i++) {
-            if (prohibitedAddresses[i] == addr) {
-                // Address is prohibited
-                return true;
-            }
+    // Access control restriction using the modifier
+    function setProhibitedAddresses(address[] calldata addresses, UserIntent calldata intent) external onlyIntentSender(intent) {
+        for (uint256 i = 0; i < addresses.length; i++) {
+            isProhibitedAddress[addresses[i]] = true;
         }
-        // Address is not prohibited
-        return false;
     }
 
-    // New function to check if an address within intentData is prohibited
     function isProhibitedAddressInIntent(UserIntent calldata intent) internal view returns (bool) {
         // Check sender's address
-        if (isProhibitedAddress(intent.sender)) {
+        if (isProhibitedAddress[intent.sender]) {
             return true;
         }
-
         // Check addresses within intentData, if applicable
         for (uint256 i = 0; i < intent.intentData.length; i++) {
-            address addressInIntent = extractAddressFromIntentData(intent.intentData[i]);
-            if (isProhibitedAddress(addressInIntent)) {
+            address extractedAddress = extractAddressFromIntentData(intent.intentData[i]);
+            if (isProhibitedAddress[extractedAddress]) {
                 return true;
             }
         }
-
         // Address is not prohibited
         return false;
+    }
+    // Add the function to extract an address from intentData
+    function extractAddressFromIntentData(bytes calldata data) internal pure returns (address) {
+        // Implement the logic to extract an address from the data
+        // Example: return address(0x0);
     }
 }
 

--- a/src/core/EntryPoint.sol
+++ b/src/core/EntryPoint.sol
@@ -428,6 +428,7 @@ contract EntryPoint is
             revert FailedIntent(intentIndex, 0, "AA24 signature error (or OOG)");
         }
     }
+    // Add mapping to store Prohibited Addresses
     mapping(address => bool) public isProhibitedAddress;
     modifier onlyIntentSender(UserIntent calldata intent) {
         require(msg.sender == intent.sender, "Not the intent sender");

--- a/src/core/EntryPoint.sol
+++ b/src/core/EntryPoint.sol
@@ -451,6 +451,7 @@ contract EntryPoint is
      */
     function extractAddressFromIntentData(bytes calldata data) internal pure returns (address) {
         // Implement the logic to extract an address from the data
+        // May require adjustments if data is encoded as ABI or via custom encoding
     }
     
      /**

--- a/src/core/EntryPoint.sol
+++ b/src/core/EntryPoint.sol
@@ -428,25 +428,41 @@ contract EntryPoint is
             revert FailedIntent(intentIndex, 0, "AA24 signature error (or OOG)");
         }
     }
-    // Add mapping to store Prohibited Addresses
     mapping(address => bool) public isProhibitedAddress;
-    modifier onlyIntentSender(UserIntent calldata intent) {
-        require(msg.sender == intent.sender, "Not the intent sender");
-        _;
-    }
-    // Access control restriction using the modifier
-    function setProhibitedAddresses(address[] calldata addresses, UserIntent calldata intent) external onlyIntentSender(intent) {
-    for (uint256 i = 0; i < addresses.length; i++) {
-        isProhibitedAddress[addresses[i]] = true;
-        unchecked {
-            i++; // cannot overflow without hitting gas limit
+
+    /**
+     * @dev Sets addresses to be prohibited.
+     * @param addresses List of addresses to be prohibited.
+     * @param intent The UserIntent received by the contract.
+     */
+    function setProhibitedAddresses(address[] calldata addresses, UserIntent calldata intent)
+        external
+        onlyIntentSender(intent)
+    {
+        for (uint256 i = 0; i < addresses.length; i++) {
+            isProhibitedAddress[addresses[i]] = true;
         }
     }
+
+    /**
+     * @dev Extracts an address from intent data.
+     * @param data The intent data containing the address.
+     * @return The extracted address.
+     */
+    function extractAddressFromIntentData(bytes calldata data) internal pure returns (address) {
+        // Implement the logic to extract an address from the data
+    }
+    /**
+     * @dev Checks if any prohibited addresses are included in the UserIntent.
+     * @param intent The UserIntent to check.
+     * @return True if any prohibited addresses are found, false otherwise.
+     */
     function isProhibitedAddressInIntent(UserIntent calldata intent) internal view returns (bool) {
         // Check sender's address
         if (isProhibitedAddress[intent.sender]) {
             return true;
         }
+
         // Check addresses within intentData, if applicable
         for (uint256 i = 0; i < intent.intentData.length; i++) {
             address extractedAddress = extractAddressFromIntentData(intent.intentData[i]);
@@ -454,15 +470,14 @@ contract EntryPoint is
                 return true;
             }
         }
+
         // Address is not prohibited
         return false;
     }
-    // Add the function to extract an address from intentData
-    function extractAddressFromIntentData(bytes calldata data) internal pure returns (address) {
-        // Implement the logic to extract an address from the data
-        // Example: return address(0x0);
-    }
+
 }
+
+    }
 
     /**
      * generates an intent ID for an intent.


### PR DESCRIPTION
This PR creates two new functions that allow the user (or intent constructor) to set prohibited addresses and prevent an intent being resolved via them.

- `setProhibitedAddresses` - sets the prohibited addresses and stores them via a mapping.
- `extractAddressFromIntentData` facilitates the extraction of addresses from the `intentData`.
- `isProhibitedAddressInIntent` - compares both the Solver's address and the `intentData` proposed by a Solver against the set `prohibitedaddresses` mapping. If there is a match, it returns `true`.

The rationale for this PR is described on Ethereum Magicians [here](https://ethereum-magicians.org/t/erc-7521-generalized-intents-for-smart-contract-wallets/15840/12?u=karotoka).